### PR TITLE
Added support for skip to content links and iOS VoiceOver compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2024-03-26
+
+### New
+
+- Support for iOS VoiceOver
+- New optional Skip to Content link
+
 ## [2.2.0] - 2022-08-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -128,13 +128,18 @@ Always include the safe filter when using Nunjucks.
   listType: 'ol',
   listClass: 'nav-toc-list',
   listItemClass: 'nav-toc-list-item',
-  listItemAnchorClass: 'nav-toc-list-item-anchor'
+  listItemAnchorClass: 'nav-toc-list-item-anchor',
+  skipLink: false,
+  skipLinkClass: 'nav-toc-skip',
+  skipLinkTag: 'a',
+  skipLinkTargetId: 'nav-toc-content',
+  skipLinkText: 'Skip to Content'
 }
 ```
 
 | Option                | Data Type | Description                                        | Notes                                                                                                           |
 | --------------------- | --------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `tags`                | Object     | An array of heading levels to include in the TOC.  | Page titles (i.e. `h1`) should be excluded.                                                                     |
+| `tags`                | Object    | An array of heading levels to include in the TOC.  | Page titles (i.e. `h1`) should be excluded.                                                                     |
 | `wrapper`             | String    | The navigation landmark element of the TOC.        | In most cases use `nav`. If you replace it, be sure it’s valid HTML and accessible.                             |
 | `wrapperClass`        | String    | The CSS class name for the TOC parent element.     | Using an empty string removes the `class` attribute.                                                            |
 | `heading`             | Boolean   | Whether the TOC uses a heading element.            | Using heading text for sections helps everyone.                                                                 |
@@ -145,6 +150,11 @@ Always include the safe filter when using Nunjucks.
 | `listClass`           | String    | The CSS class name for the list.                   | Using an empty string removes the `class` attribute.                                                            |
 | `listItemClass`       | String    | The CSS class name for each list item.             | Using an empty string removes the `class` attribute.                                                            |
 | `listItemAnchorClass` | String    | The CSS class name for each anchor in a list item. | Using an empty string removes the `class` attribute.                                                            |
+| `skipLink`            | Boolean   | Whether to render a skip to content link or not.   | This will appear below the header tag.                                                                          |
+| `skipLinkClass`       | String    | The CSS class name for the skip to content link.   |                                                                                                                 |
+| `skipLinkTag`         | String    | The tag name for the skip to content link.         | In case you opt for a button. The href will still render as is so that could be leveraged with JavaScript.      |
+| `skipLinkTargetId`    | String    | The `id` for the link's href                       |                                                                                                                 |
+| `skipLinkText`        | String    | The text for the skip to content link.             |                                                                                                                 |
 
 ### Override Default Options
 

--- a/toc.js
+++ b/toc.js
@@ -14,6 +14,11 @@ const cheerio = require( 'cheerio' ),
     listClass: 'nav-toc-list',
     listItemClass: 'nav-toc-list-item',
     listItemAnchorClass: 'nav-toc-list-item-anchor',
+    skipLink: false,
+    skipLinkClass: 'nav-toc-skip',
+    skipLinkTag: 'a',
+    skipLinkTargetId: 'nav-toc-content',
+    skipLinkText: 'Skip to Content',
   };
 
 // Verify "tags" option values are correct
@@ -48,12 +53,12 @@ function checkTags( value, key ) {
   }
 }
 
-// Verify "heading" option value is correct
-function checkHeading( value ) {
+// Verify "heading" and "skipLink" option values are correct
+function checkBoolean( value, key ) {
   const optionToCheck = value;
 
   if ( optionToCheck.length > 0 && typeof optionToCheck !== 'boolean' ) {
-    console.error( '\n⛔ Error (ToC): The “heading” option needs a Boolean value.\n' );
+    console.error( '\n⛔ Error (ToC): The “' + key + '” option needs a Boolean value.\n' );
 
     return false;
   }
@@ -86,15 +91,18 @@ function checkLength( value, key ) {
 
 // Run the checks
 checkTags( defaults.tags, 'tags' );
-checkHeading( defaults.heading );
+checkBoolean( defaults.heading, 'heading' );
 checkTags( defaults.headingLevel, 'headingLevel' );
 checkListType( defaults.listType );
 checkLength( defaults.tags, 'tags' );
 checkLength( defaults.wrapper, 'wrapper' );
-checkLength( defaults.heading, 'heading' );
 checkLength( defaults.headingLevel, 'headingLevel' );
 checkLength( defaults.headingText, 'headingText' );
 checkLength( defaults.listType, 'listType' );
+checkBoolean( defaults.skipLink, 'skipLink' );
+checkLength( defaults.skipLinkTag, 'skipLinkTag' );
+checkLength( defaults.skipLinkText, 'skipLinkText' );
+
 
 function getParent( prev, current ) {
   if ( current.level > prev.level ) {
@@ -201,15 +209,16 @@ class Toc {
   }
 
   html() {
-    const { wrapper, wrapperClass, heading, headingClass, headingLevel, headingText } = this.options,
+    const { wrapper, wrapperClass, heading, headingClass, headingLevel, headingText, skipLink, skipLinkClass, skipLinkTag, skipLinkTargetId, skipLinkText } = this.options,
       root = this.get(),
-      markupWrapperStart = `<${wrapper} role="navigation" aria-label="${headingText}">`,
-      markupWrapperStartClass = `<${wrapper} class="${wrapperClass}" role="navigation" aria-label="${headingText}">`,
-      markupWrapperHeadingStart = `<${wrapper} role="navigation" aria-labelledby="${wrapperClass}">`,
-      markupWrapperHeadingStartClass = `<${wrapper} class="${wrapperClass}" role="navigation" aria-labelledby="${wrapperClass}">`,
-      markupHeading = `<${headingLevel} id="${wrapperClass}">${headingText}</${headingLevel}>`,
-      markupHeadingClass = `<${headingLevel} class="${headingClass}" id="${wrapperClass}">${headingText}</${headingLevel}>`,
-      markupWrapperEnd = `${root.html()}</${wrapper}>`;
+      markupWrapperStart = `<${wrapper} role="navigation" aria-label="${headingText}" id="${wrapperClass}-nav" tabindex="-1">`,
+      markupWrapperStartClass = `<${wrapper} class="${wrapperClass}" role="navigation" aria-label="${headingText}" id="${wrapperClass}-nav" tabindex="-1">`,
+      markupWrapperHeadingStart = `<${wrapper} role="navigation" aria-labelledby="${wrapperClass}" id="${wrapperClass}-nav" tabindex="-1">`,
+      markupWrapperHeadingStartClass = `<${wrapper} class="${wrapperClass}" role="navigation" aria-labelledby="${wrapperClass}" id="${wrapperClass}-nav" tabindex="-1">`,
+      markupHeading = `<${headingLevel} id="${wrapperClass}" tabindex="-1">${headingText}</${headingLevel}>`,
+      markupHeadingClass = `<${headingLevel} class="${headingClass}" id="${wrapperClass}" tabindex="-1">${headingText}</${headingLevel}>`,
+      markupWrapperEnd = `${root.html()}</${wrapper}>`,
+      markupSkipLink = `<${skipLinkTag} href="#${skipLinkTargetId}" class="${skipLinkClass}">${skipLinkText}</${skipLinkTag}>`;
 
     let html = '';
 
@@ -247,6 +256,10 @@ class Toc {
             console.error( 'Please add a heading level.' );
           }
         }
+      }
+
+      if (skipLink) {
+        html += markupSkipLink;
       }
 
       html += markupWrapperEnd;


### PR DESCRIPTION
1. Add support for [Skip to Links](https://webaim.org/techniques/skipnav/) within the table of contents after the header
2. Add support for the table of contents to be skipped _to_.

In iOS with VoiceOver, clicking to a destination may scroll upward or kind of latch onto the nearest tabbable interface instead of the #target. If we add a `tabindex="-1"` to the target, there's a better chance it will latch on. Ergo adding an `id` to the nav wrapper and `tabindex="-1"` to both the wrapper and heading so users have a choice of where in the nav they want to skip to if at all. The tabindex isn't given a choice as it's -1 and opt-in in and of itself in terms of only being tabbable/focused via programming.